### PR TITLE
Upload

### DIFF
--- a/api/v1/handlers/transcoder/transcode.go
+++ b/api/v1/handlers/transcoder/transcode.go
@@ -63,7 +63,7 @@ func Transcode(c *fiber.Ctx) error {
 	}
 
 	//Use ffmpeg to transcode the file into 4 different resolutions: 1080p, 720p, 480p, 360p (reversed resolution dimensions)
-	resolutions := []string{"360x640", "480x854"}
+	resolutions := []string{"360x640", "480x854", "720x1280", "1080x1920"}
 	go Service.TranscodeAndUpload(resolutions, filename, c)
 
 	//Return filename

--- a/api/v1/handlers/transcoder/transcode.go
+++ b/api/v1/handlers/transcoder/transcode.go
@@ -12,7 +12,7 @@ func Transcode(c *fiber.Ctx) error {
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": fiber.Map{
-				"code":    "E0002",
+				"code":    "E0009",
 				"message": "Upload request does not contain a file",
 			},
 		})
@@ -23,7 +23,7 @@ func Transcode(c *fiber.Ctx) error {
 	if filename == "" {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": fiber.Map{
-				"code":    "E0003",
+				"code":    "E0010",
 				"message": "Upload request does not contain a fileName",
 			},
 		})
@@ -35,7 +35,7 @@ func Transcode(c *fiber.Ctx) error {
 	if !contains(allowedTypes, contentType) {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": fiber.Map{
-				"code":    "E0004",
+				"code":    "E0011",
 				"message": "File type not allowed",
 			},
 		})
@@ -56,7 +56,7 @@ func Transcode(c *fiber.Ctx) error {
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": fiber.Map{
-				"code":    "E0005",
+				"code":    "E0012",
 				"message": "Unable to save the file",
 			},
 		})

--- a/api/v1/handlers/transcoder/transcode.go
+++ b/api/v1/handlers/transcoder/transcode.go
@@ -1,11 +1,9 @@
 package transcoder
 
 import (
-	GCPService "github.com/Educado-App/educado-transcoding-service/internals/gcp"
 	Service "github.com/Educado-App/educado-transcoding-service/internals/transcoder"
 	"github.com/gofiber/fiber/v2"
 	"os"
-	"sync"
 )
 
 func Transcode(c *fiber.Ctx) error {
@@ -64,55 +62,9 @@ func Transcode(c *fiber.Ctx) error {
 		})
 	}
 
-	//Wait group to wait for all transcodes to finish
-	wg := sync.WaitGroup{}
-
 	//Use ffmpeg to transcode the file into 4 different resolutions: 1080p, 720p, 480p, 360p (reversed resolution dimensions)
-	resolutions := []string{"360x640"}
-	for _, resolution := range resolutions {
-		outputPath := "./tmp/" + filename + "_" + resolution + ".mp4"
-		wg.Add(1)
-		go Service.TranscodeVideo("./tmp/"+filename, outputPath, resolution, &wg)
-	}
-
-	//Wait for all transcodes to finish
-	wg.Wait()
-
-	//Delete the original file
-	err = os.Remove("./tmp/" + filename)
-	if err != nil {
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": fiber.Map{
-				"code":    "E0006",
-				"message": "Unable to delete the original file",
-			},
-		})
-	}
-
-	//Upload the transcoded files to the bucket
-	for _, resolution := range resolutions {
-		localFilePath := "./tmp/" + filename + "_" + resolution + ".mp4"
-		file, err := Service.FileToBytes(localFilePath)
-		err = GCPService.Service.UploadFile(filename+"_"+resolution+".mp4", file)
-		if err != nil {
-			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-				"error": fiber.Map{
-					"code":    "E0007",
-					"message": "Unable to upload the transcoded file",
-				},
-			})
-		}
-		//Delete the transcoded file
-		err = os.Remove(localFilePath)
-		if err != nil {
-			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-				"error": fiber.Map{
-					"code":    "E0008",
-					"message": "Unable to delete the transcoded file",
-				},
-			})
-		}
-	}
+	resolutions := []string{"360x640", "480x854"}
+	go Service.TranscodeAndUpload(resolutions, filename, c)
 
 	//Return filename
 	return c.JSON(fiber.Map{

--- a/api/v1/handlers/transcoder/transcode.go
+++ b/api/v1/handlers/transcoder/transcode.go
@@ -1,9 +1,11 @@
 package transcoder
 
 import (
+	GCPService "github.com/Educado-App/educado-transcoding-service/internals/gcp"
 	Service "github.com/Educado-App/educado-transcoding-service/internals/transcoder"
 	"github.com/gofiber/fiber/v2"
 	"os"
+	"sync"
 )
 
 func Transcode(c *fiber.Ctx) error {
@@ -62,11 +64,54 @@ func Transcode(c *fiber.Ctx) error {
 		})
 	}
 
-	//Use ffmpeg to transcode the file into 4 different resolutions
-	resolutions := []string{"1920x1080"}
+	//Wait group to wait for all transcodes to finish
+	wg := sync.WaitGroup{}
+
+	//Use ffmpeg to transcode the file into 4 different resolutions: 1080p, 720p, 480p, 360p (reversed resolution dimensions)
+	resolutions := []string{"360x640"}
 	for _, resolution := range resolutions {
 		outputPath := "./tmp/" + filename + "_" + resolution + ".mp4"
-		go Service.TranscodeVideo("./tmp/"+filename, outputPath, resolution)
+		wg.Add(1)
+		go Service.TranscodeVideo("./tmp/"+filename, outputPath, resolution, &wg)
+	}
+
+	//Wait for all transcodes to finish
+	wg.Wait()
+
+	//Delete the original file
+	err = os.Remove("./tmp/" + filename)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": fiber.Map{
+				"code":    "E0006",
+				"message": "Unable to delete the original file",
+			},
+		})
+	}
+
+	//Upload the transcoded files to the bucket
+	for _, resolution := range resolutions {
+		localFilePath := "./tmp/" + filename + "_" + resolution + ".mp4"
+		file, err := Service.FileToBytes(localFilePath)
+		err = GCPService.Service.UploadFile(filename+"_"+resolution+".mp4", file)
+		if err != nil {
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+				"error": fiber.Map{
+					"code":    "E0007",
+					"message": "Unable to upload the transcoded file",
+				},
+			})
+		}
+		//Delete the transcoded file
+		err = os.Remove(localFilePath)
+		if err != nil {
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+				"error": fiber.Map{
+					"code":    "E0008",
+					"message": "Unable to delete the transcoded file",
+				},
+			})
+		}
 	}
 
 	//Return filename

--- a/internals/transcoder/transcoderService.go
+++ b/internals/transcoder/transcoderService.go
@@ -55,7 +55,7 @@ func TranscodeAndUpload(resolutions []string, filename string, c *fiber.Ctx) err
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": fiber.Map{
-				"code":    "E0006",
+				"code":    "E0013",
 				"message": "Unable to delete the original file",
 			},
 		})
@@ -69,7 +69,7 @@ func TranscodeAndUpload(resolutions []string, filename string, c *fiber.Ctx) err
 		if err != nil {
 			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 				"error": fiber.Map{
-					"code":    "E0007",
+					"code":    "E0014",
 					"message": "Unable to upload the transcoded file",
 				},
 			})
@@ -79,7 +79,7 @@ func TranscodeAndUpload(resolutions []string, filename string, c *fiber.Ctx) err
 		if err != nil {
 			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 				"error": fiber.Map{
-					"code":    "E0008",
+					"code":    "E0015",
 					"message": "Unable to delete the transcoded file",
 				},
 			})

--- a/internals/transcoder/transcoderService.go
+++ b/internals/transcoder/transcoderService.go
@@ -1,11 +1,17 @@
 package transcoder
 
 import (
+	"bufio"
 	"log"
+	"os"
 	"os/exec"
+	"sync"
 )
 
-func TranscodeVideo(inputPath, outputPath, resolution string) {
+func TranscodeVideo(inputPath, outputPath, resolution string, wg *sync.WaitGroup) {
+	// Decrement the counter when the goroutine completes.
+	defer wg.Done()
+
 	cmd := exec.Command("ffmpeg", "-i", inputPath, "-s", resolution, outputPath)
 	err := cmd.Run()
 	if err != nil {
@@ -13,4 +19,18 @@ func TranscodeVideo(inputPath, outputPath, resolution string) {
 		return
 	}
 	log.Printf("Transcoding to resolution %s completed: %s", resolution, outputPath)
+}
+
+func FileToBytes(filePath string) ([]byte, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	fileInfo, _ := file.Stat()
+	var size int64 = fileInfo.Size()
+	bytes := make([]byte, size)
+	buffer := bufio.NewReader(file)
+	_, err = buffer.Read(bytes)
+	return bytes, err
 }


### PR DESCRIPTION
## Description

The API now is able to transcode and upload using the 
```
POST api/v1/transcoder
```
Sending the following formData:
```
file: <file>
fileName: <name of file on the bucket>
```


## Changes

Before the files did not upload to GCP, but now it does. It also deletes the temp files after. 

## Related Issues

List any related issues or tickets that this pull request addresses or resolves.

## Checklist

- [x] Code has been tested locally and passes all relevant tests.
- [x] Documentation has been updated to reflect the changes, if applicable.
- [x] Code follows the established coding style and guidelines of the project.
- [x] All new and existing tests related to the changes have passed.
- [x] Any necessary dependencies or new packages have been properly documented.
- [x] Pull request title and description are clear and descriptive.
- [x] Reviewers have been assigned to the pull request.
- [x] Any potential security implications have been considered and addressed.
- [x] Performance impact of the changes has been evaluated, if relevant.

## Screenshots (if applicable)

NIL

## If mobile/frontend pull request, what version of the backend is it stable, and running on? 

Works with this educado-mobile commit id: 4885ed4 (feature_change_resolution)
And this backend commit id: 12c46fd (dev)