### PR TITLE
Download file endpoint now returns file with correct header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ gcp_credentials.json
 .DS_Store
 educado.out
 ./tmp/**
+config/gcp_service.json

--- a/api/v1/handlers/bucket/download.go
+++ b/api/v1/handlers/bucket/download.go
@@ -2,26 +2,56 @@ package bucket
 
 import (
 	"encoding/base64"
+	"mime"
+	"net/http"
+	"path/filepath"
+
 	"github.com/Educado-App/educado-transcoding-service/api/v1/common"
 	"github.com/Educado-App/educado-transcoding-service/internals/gcp"
 	"github.com/gofiber/fiber/v2"
 )
 
 func DownloadFile(c *fiber.Ctx) error {
-	// Get filename from URL
-	var filename = c.Params("fileName")
+    // Get filename from URL
+    var filename = c.Params("fileName")
 
-	// Download file from GCP
-	var file, err = gcp.Service.DownloadFile(filename)
-	if err != nil {
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": common.Error{
-				Code:    "E0001",
-				Message: err.Error(),
-			},
-		})
-	}
+    // Download file from GCP
+    var file, err = gcp.Service.DownloadFile(filename)
+    if err != nil {
+        return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+            "error": common.Error{
+                Code:    "E0001",
+                Message: err.Error(),
+            },
+        })
+    }
 
-	// Encode file to base64 for frontend
-	return c.SendString(base64.StdEncoding.EncodeToString(file))
+	// Get file attributes to set additional headers
+    attrs, err := gcp.Service.GetFileAttributes(filename)
+    if err != nil {
+        return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+            "error": common.Error{
+                Code:    "E0002",
+                Message: err.Error(),
+            },
+        })
+    }
+
+    // Determine the MIME type based on the file extension
+    mimeType := mime.TypeByExtension(filepath.Ext(filename))
+    if mimeType == "" {
+		// If the file has no file extension, return the file as a base64 encoded string (Old way)
+		// TODO: Remove this in the future, once all files have a file extension
+		return c.SendString(base64.StdEncoding.EncodeToString(file))
+    }
+
+    // Set the Content-Type header
+    c.Set(fiber.HeaderContentType, mimeType)
+
+	// Set the Last-Modified header
+    lastModified := attrs.Updated.Format(http.TimeFormat)
+    c.Set(fiber.HeaderLastModified, lastModified)
+
+    // Send the file as a binary response
+    return c.Send(file)
 }

--- a/internals/gcp/gcpService.go
+++ b/internals/gcp/gcpService.go
@@ -1,10 +1,11 @@
 package gcp
 
 import (
-	"cloud.google.com/go/storage"
 	"context"
-	"google.golang.org/api/iterator"
 	"io"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/iterator"
 )
 
 var Service = newGCPService()
@@ -55,6 +56,14 @@ func (s *GCPService) DownloadFile(fileName string) ([]byte, error) {
 		return nil, err
 	}
 	return content, nil
+}
+
+func (s *GCPService) GetFileAttributes(fileName string) (*storage.ObjectAttrs, error) {
+    attrs, err := s.client.Bucket(s.bucketName).Object(fileName).Attrs(s.context)
+    if err != nil {
+        return nil, err
+    }
+    return attrs, nil
 }
 
 func (s *GCPService) UploadFile(fileName string, content []byte) error {


### PR DESCRIPTION
## Description

This PR changes the DownloadFile endpoint, so that it returns the file with the correct headers, instead of just returning the base64 string, without any information about the file type.

## Changes

The downloadFile endpoint now looks at the file extension in the file name, and sets the content-type header based off of this. It also gets the file attributes so that we can set the last-modified header, so that the picture can be correctly cached by the frontend.

## Related Issues

Fixes #11 and fixes #12 

## Checklist

- [x] Code has been tested locally and passes all relevant tests.
- [x] Documentation has been updated to reflect the changes, if applicable.
- [x] Code follows the established coding style and guidelines of the project.
- [x] All new and existing tests related to the changes have passed.
- [x] Any necessary dependencies or new packages have been properly documented.
- [x] Pull request title and description are clear and descriptive.
- [x] Reviewers have been assigned to the pull request.
- [x] Any potential security implications have been considered and addressed.
- [x] Performance impact of the changes has been evaluated, if relevant.
